### PR TITLE
feat: Implemented modal windows for show messages

### DIFF
--- a/src/components/modal/Modal.css
+++ b/src/components/modal/Modal.css
@@ -1,0 +1,49 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 99;
+}
+
+.modal-content {
+  background: white;
+  padding: 20px;
+  border-radius: 10px;
+  max-width: 500px;
+  width: 85%;
+  max-height: 80vh;
+  overflow-y: auto;
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0 5px;
+}
+
+.modal-title {
+  margin-top: 0;
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.modal-message {
+  text-align: center;
+}
+
+.modal-buttons {
+  display: flex;
+  justify-content: space-around;
+}

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -1,0 +1,46 @@
+import React, { ReactNode, useEffect } from 'react';
+
+import './Modal.css';
+
+export interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  title?: string;
+  message?: string;
+}
+
+export const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, title, message }) => {
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+      document.body.style.overflow = 'auto';
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        {title && <h2 className="modal-title">{title}</h2>}
+        {message && <p className="modal-message">{message}</p>}
+        <button className="modal-close" onClick={onClose}>
+          ×
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/src/components/modal/modalWindow.tsx
+++ b/src/components/modal/modalWindow.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { Modal, ModalProps } from './Modal';
+
+type ModalOptions = {
+  title?: string;
+  message?: string;
+  buttons?: React.ReactNode;
+  onClose?: () => void;
+};
+
+let modalRoot: HTMLDivElement | undefined;
+let root: Root | undefined;
+
+export const modalWindow = {
+  show: (options: ModalOptions): void => {
+    if (!modalRoot) {
+      modalRoot = document.createElement('div');
+      modalRoot.id = 'modal-root';
+      document.body.appendChild(modalRoot);
+      root = createRoot(modalRoot);
+    }
+
+    const handleClose = (): void => {
+      modalWindow.hide();
+      options.onClose?.();
+    };
+
+    const modalProps: ModalProps = {
+      isOpen: true,
+      onClose: handleClose,
+      title: options.title,
+      message: options.message,
+      children: options.buttons,
+    };
+
+    root!.render(React.createElement(Modal, modalProps));
+  },
+
+  hide: (): void => {
+    if (modalRoot && root) {
+      root.unmount();
+      document.body.removeChild(modalRoot);
+      modalRoot = undefined;
+      root = undefined;
+    }
+  },
+
+  alert: (message: string, title = 'Notification'): void => {
+    modalWindow.show({
+      title,
+      message,
+      buttons: (
+        <div className="modal-buttons">
+          <button onClick={() => modalWindow.hide()}>Close</button>
+        </div>
+      ),
+    });
+  },
+
+  confirm: (message: string, title = 'Confirmation'): Promise<boolean> => {
+    return new Promise((resolve) => {
+      modalWindow.show({
+        title,
+        message,
+        buttons: (
+          <div className="modal-buttons">
+            <button
+              onClick={() => {
+                modalWindow.hide();
+                resolve(false);
+              }}
+            >
+              No
+            </button>
+            <button
+              onClick={() => {
+                modalWindow.hide();
+                resolve(true);
+              }}
+            >
+              Yes
+            </button>
+          </div>
+        ),
+      });
+    });
+  },
+};


### PR DESCRIPTION
Creates a modal window with the given parameters and removes it from the DOM after use.

Example for use:

import { modalWindow } from '../../components/modal/modalWindow';

modalWindow.alert( 'Information notice!');

modalWindow.confirm( 'A request returning a promise true/false!');